### PR TITLE
update to v3, include actual non-ascii text

### DIFF
--- a/draft-iab-rfc-nonascii-bis.xml
+++ b/draft-iab-rfc-nonascii-bis.xml
@@ -1,55 +1,42 @@
-<?xml version="1.0" encoding="US-ASCII"?>
-
-<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
-
-<!ENTITY RFC4475 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4475.xml">
-<!ENTITY RFC6949 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6949.xml">
-<!ENTITY RFC7322 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7322.xml">
-<!ENTITY RFC7564 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7564.xml">
-<!ENTITY RFC7613 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7613.xml">
-]>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
-
 <?rfc toc="yes"?>
-<?rfc tocompact="yes"?>
-<?rfc tocdepth="3"?>
-<?rfc tocindent="yes"?>
 <?rfc symrefs="yes"?>
 <?rfc sortrefs="yes"?>
+<?rfc compact="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes"?>
-<?rfc compact="yes"?>
-<?rfc subcompact="no"?>
-
-<rfc submissionType="IAB" consensus="yes" category="info" number="7997" ipr="trust200902" updates="7322">
-<front>
- <title abbrev="Non-ASCII in RFCs">The Use of Non-ASCII Characters in RFCs</title>
-
- <author fullname="Heather Flanagan" initials="H." role="editor"
-            surname="Flanagan">
-    <organization>RFC Editor</organization>
-    <address>
-      <postal>
-        <street></street>
-        <city></city>
-        <region></region>
-        <code></code>
-        <country></country>
-      </postal>
-      <phone></phone>
-      <email>rse@rfc-editor.org</email>
-      <uri>http://orcid.org/0000-0002-2647-2220</uri>
-   </address>
- </author>
-
- <date month="December" year="2016"/>
-
- <area>General</area>
- <workgroup>Internet Architecture Board</workgroup>
- <keyword>RFC Series, UTF-8, ASCII, format, non-ASCII</keyword>
-
- <abstract>
-   <t>
+<?rfc linkmailto="no" ?>
+<?rfc rfcedstyle="yes"?>
+<!DOCTYPE rfc SYSTEM "rfc2629-xhtml.ent">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude"
+     docName="draft-iab-rfc-nonascii-bis-00"
+     submissionType="IAB"
+    consensus="yes"
+    obsoletes="7997"
+	  ipr="trust200902"
+     category="info"
+     xml:lang="en" updates=""
+   tocInclude="true"
+      symRefs="true"
+     sortRefs="true"
+      version="3">
+  <!-- xml2rfc v2v3 conversion 2.41.0 -->
+  <front>
+    <title abbrev="Non-ASCII in RFCs">The Use of Non-ASCII Characters in RFCs</title>
+    <author fullname="John Levine" initials="J." role="editor" surname="Levine">
+      <organization>Temporary RFC Series Project Manager</organization>
+      <address>
+	 <email>standards@standcore.com</email>
+	 <uri>http://orcid.org/0000-0001-7553-5024</uri>
+      </address>
+    </author>
+    <date year="2020"/>
+    <area>General</area>
+    <workgroup>Internet Architecture Board</workgroup>
+    <keyword>RFC Series, UTF-8, ASCII, format, non-ASCII</keyword>
+    <abstract>
+      <t>
 In order to support the internationalization of protocols and a more
 diverse Internet community, the RFC Series must evolve to allow for 
 the use of non-ASCII characters in RFCs.  While English remains the 
@@ -57,41 +44,33 @@ required language of the Series, the encoding of future RFCs will
 be in UTF-8, allowing for a broader range of characters than typically
 used in the English language.  This document describes the RFC Editor 
 requirements and gives guidance regarding the use of non-ASCII characters in RFCs.
-   </t>
-   <t>
-This document updates RFC 7322. Please view this document in PDF form to see the full text.
-   </t>
- </abstract>
-</front>
-
-
-<middle>
-
-<section title="Introduction">
-<t>
-Please review the PDF version of this draft. 
-</t>
-<t>
+      </t>
+    </abstract>
+  </front>
+  <middle>
+    <section numbered="true" toc="default">
+      <name>Introduction</name>
+      <t>
 For much of the history of the RFC Series, the character encoding used
-for RFCs has been <xref target="RFC20">ASCII</xref>.  
+for RFCs has been <xref target="RFC20" format="default">ASCII</xref>.  
 This was a sensible choice at the time: the language of the Series has
 always been English, a language that primarily uses ASCII-encoded characters 
 (ignoring for a moment words borrowed from more richly decorated alphabets); 
 and, ASCII is the "lowest common denominator" for character encoding, making 
 cross-platform viewing trivial.
 </t>
-<t>
+      <t>
 There are limits to ASCII, however, that hinder its continued use as the
 exclusive character encoding for the Series.  The increasing need for 
 easily readable, internationalized content suggests it is time to allow 
 non-ASCII characters in RFCs where necessary.  To support this move away 
 from ASCII, RFCs will switch to supporting UTF-8 as the default character 
 encoding and will allow support for a broad range of Unicode characters 
-<xref target="UnicodeCurrent"/>.  Note that the RFC Editor may reject any code point that does not render 
+<xref target="UnicodeCurrent" format="default"/>.  Note that the RFC Editor may reject any code point that does not render 
 adequately across all formats or in enough rendering engines using the v3
 tooling.
 </t>
-<t>
+      <t>
 Given the continuing goal of maximum readability across platforms, the
 use of non-ASCII characters should be limited to only where 
 necessary within the text.  This document describes the rules under which 
@@ -99,77 +78,73 @@ non-ASCII characters may be used in an RFC.  These rules will be applied
 as the necessary changes are made to submission checking and editorial
 tools.
 </t>
-<t>
-This document updates the <xref target="RFC7322">RFC Style Guide</xref>.
+      <t>
+This document updates the <xref target="RFC7322" format="default">RFC Style Guide</xref>.
 </t>
-<t>The details included in this document are expected to change based on
+      <t>The details included in this document are expected to change based on
 experience gained in implementing the new publication toolsets. Revised
 documents will be published capturing those changes as the toolsets are
 completed. Other implementers must not expect those changes to remain
-backwards compatible with the details included in this document.</t> 
-
-
-</section>
-
-<section title="Basic Requirements">
-<t>
+backwards compatible with the details included in this document.</t>
+    </section>
+    <section numbered="true" toc="default">
+      <name>Basic Requirements</name>
+      <t>
 Two fundamental requirements inform the guidance and examples provided
 in this document.  They are:
 </t>
-<t><list style="symbols">
-  <t>Searches against RFC indexes and database tables need to return
+      <ul spacing="normal">
+        <li>Searches against RFC indexes and database tables need to return
 expected results and support appropriate Unicode string matching
-behaviors; </t>
-
-  <t>RFCs must be able to be displayed correctly across a wide range of
+behaviors; </li>
+        <li>RFCs must be able to be displayed correctly across a wide range of
 readers and browsers.  People whose systems do not have the fonts needed to
 display a particular RFC need to be able to read the various publication 
 formats and the XML correctly in order to understand and implement the 
-information described in the document.</t>
-</list>
-</t>
-</section>
-
-<section title="Rules for the Use of Non-ASCII Characters">
-<t>
+information described in the document.</li>
+      </ul>
+    </section>
+    <section numbered="true" toc="default">
+      <name>Rules for the Use of Non-ASCII Characters</name>
+      <t>
 This section describes the guidelines for the use of non-ASCII characters 
 in an RFC.  If the RFC Editor identifies areas where the use of non-ASCII 
 characters negatively impacts 
 the readability of the text, they will request alternate text.
 </t>
-<t>
+      <t>
 The RFC Editor may, in cases of entire words represented in non-ASCII
 characters, ask for a set of reviewers to verify the meaning, spelling, 
 characters, and grammar of the text.
 </t>
-
-<section title="General Usage throughout a Document">
-<t>
+      <section numbered="true" toc="default">
+        <name>General Usage throughout a Document</name>
+        <t>
 Where the use of non-ASCII characters is purely part of an example
 and not otherwise required for correct protocol operation, escaping 
 the non-ASCII character is not required.  Note, however, that as the 
 language of the RFC Series is English, the use of non-ASCII characters 
 is based on the spelling of words commonly used in the English language 
-following the guidance in the <xref target="MerrWeb">Merriam-Webster 
+following the guidance in the <xref target="MerrWeb" format="default">Merriam-Webster 
 dictionary</xref>. 
 </t>
-<t>
+        <t>
 The RFC Editor will use the primary spelling listed in that dictionary
 by default.
 </t>
-<t>Example of non-ASCII characters that do not require escaping
-(example from Section 3.1.1.12 of RFC 4475 <xref target="RFC4475"/>, with a hex dump
+        <t>Example of non-ASCII characters that do not require escaping
+(example from Section 3.1.1.12 of RFC 4475 <xref target="RFC4475" format="default"/>, with a hex dump
 replaced by the actual character glyphs):
 
-<figure>
-<artwork><![CDATA[
+</t>
+        <artwork name="" type="" align="left" alt=""><![CDATA[
 This particular response contains unreserved and non-ASCII
 UTF-8 characters.
 This response is well formed.  A parser must accept this message.
 
 Message Details : unreason
 
-SIP/2.0 200 = 2**3 * 5**2 (See PDF for non-ASCII character string)
+SIP/2.0 200 = 2**3 * 5**2 но сто девяносто девять - простое
 Via: SIP/2.0/UDP 192.0.2.198;branch=z9hG4bK1324923
 Call-ID: unreason.1234ksdfak3j2erwedfsASdf
 CSeq: 35 INVITE
@@ -177,25 +152,20 @@ From: sip:user@example.com;tag=11141343
 To: sip:user@example.edu;tag=2229 Content-Length: 154
 Content-Type: application/sdp
 ]]></artwork>
-</figure>
-</t>
-</section>
-
-<section title="Person Names">
-<t>
+      </section>
+      <section numbered="true" toc="default">
+        <name>Person Names</name>
+        <t>
 Person names may appear in several places within an RFC (e.g., the header, Acknowledgements, and References). When a script 
-outside the Unicode Latin blocks <xref target="UNICODE-CHART"/> is used for an
+outside the Unicode Latin blocks <xref target="UNICODE-CHART" format="default"/> is used for an
 individual name, an
 author-provided, ASCII-only identifier will appear immediately after the
 non-Latin characters, surrounded by parentheses. This will improve general
 readability of the text.
 </t>
-
-<t>Example header:</t>
-<t>OLD:</t>
-
-<figure>
-<artwork><![CDATA[                                                                       
+        <t>Example header:</t>
+        <t>OLD:</t>
+        <artwork name="" type="" align="left" alt=""><![CDATA[                                                                       
 
 Internet Engineering Task Force (IETF)                       J. Tong
 Request for Comments: 7380                                C. Bi, Ed.
@@ -206,97 +176,78 @@ ISSN: 2070-1721                                              R. Even
                                                               Huawei
                                                        November 2014
 ]]></artwork>
-</figure>
-
-<t>PROPOSED/NEW:</t>
-<figure>
-<artwork><![CDATA[
+        <t>PROPOSED/NEW:</t>
+        <artwork name="" type="" align="left" alt=""><![CDATA[
 
 Internet Engineering Task Force (IETF)                       J. Tong
 Request for Comments: 7380                                C. Bi, Ed.
 Category: Standards Track                              China Telecom
-ISSN: 2070-1721   (See PDF for non-ASCII character string) (R. Even)
-               (See PDF for non-ASCII character string) (Q. Wu), Ed.
+ISSN: 2070-1721                                   רוני אבן (R. Even)
+                                                   吴钦  (Q. Wu), Ed.
                                                             R. Huang
                                                               Huawei
                                                        November 2014
 
 ]]></artwork>
-</figure>
-
-
-<t>
+        <t>
 Example Acknowledgements section:
 </t>
-<t>OLD:</t>
-<t>
+        <t>OLD:</t>
+        <t>
 The following people contributed significant text to early versions of
 this draft: Patrik Faltstrom, William Chan, and Fred Baker.
 </t>
-<t>
+        <t>
 PROPOSED/NEW:</t>
-<t>
+        <t>
 The following people contributed significant text to early versions of this
-draft: Patrik (See PDF for non-ASCII character string) (Patrik Faltstrom), (See
-PDF for non-ASCII character string) (William Chan), and Fred Baker.
+draft: Patrik Fältström, 陈智昌 (William Chan), and Fred Baker.
 </t>
-
-<t>Example reference entry:</t>
-<t>OLD:</t>
-<figure><artwork><![CDATA[
+        <t>Example reference entry:</t>
+        <t>OLD:</t>
+        <artwork name="" type="" align="left" alt=""><![CDATA[
    [RFC6630]  Cao, Z., Deng, H., Wu, Q., and G. Zorn, Ed., "EAP
               Re-authentication Protocol Extensions for Authenticated
               Anticipatory Keying (ERP/AAK)", RFC 6630, June 2012.
 ]]></artwork>
-</figure>
-
-<t>NEW</t>
-<figure><artwork><![CDATA[
-   [RFC6630]  Cao, Z., Deng, H., (See PDF for non-ASCII character 
-              string) (Wu, Q.), and G. Zorn, Ed., "EAP
+        <t>NEW</t>
+        <artwork name="" type="" align="left" alt=""><![CDATA[
+   [RFC6630]  Cao, Z., Deng, H., 吴钦 (Wu, Q.), and G. Zorn, Ed., "EAP
               Re-authentication Protocol Extensions for Authenticated
               Anticipatory Keying (ERP/AAK)", RFC 6630, June 2012.
 ]]></artwork>
-</figure>
-</section>
-
-<section title="Company Names">
-<t>
+      </section>
+      <section numbered="true" toc="default">
+        <name>Company Names</name>
+        <t>
 Company names may appear in several places within an RFC. In all
 cases, valid Unicode is required. For names that include characters
 outside of the Unicode Latin and Latin Extended scripts, an
 author-provided, ASCII-only identifier is required to assist in searching
 and indexing of the document.
 </t>
-</section>
-
-<section anchor="botd" title="Body of the Document">
-<t>
+      </section>
+      <section anchor="botd" numbered="true" toc="default">
+        <name>Body of the Document</name>
+        <t>
 When the mention of non-ASCII characters is required for correct
  protocol operation and understanding, the characters' Unicode code 
  points must be used in the text. The addition of each character name 
  is encouraged.
 </t>
-
-<t><list style="symbols">
-  <t>Non-ASCII characters will require identifying the Unicode code
-point.</t>
-
-  <t>Use of the actual UTF-8 character (e.g., (See PDF for non-ASCII character string)) is encouraged so that
+        <ul spacing="normal">
+          <li>Non-ASCII characters will require identifying the Unicode code
+point.</li>
+          <li>Use of the actual UTF-8 character (e.g., Δ) is encouraged so that
 a reader can more easily see what the character is, if their device can
-render the text.</t>
-
-  <t>The use of the Unicode character names like "INCREMENT" in
+render the text.</li>
+          <li>The use of the Unicode character names like "INCREMENT" in
 addition to the use of Unicode code points is also encouraged.  When
-used, Unicode character names should be in all capital letters.</t>
-</list>
-</t>
-
-<t>Examples:</t>
-<t>OLD <xref target="RFC7564"/>: </t>
-
-<figure>
-<artwork><![CDATA[
+used, Unicode character names should be in all capital letters.</li>
+        </ul>
+        <t>Examples:</t>
+        <t>OLD <xref target="RFC7564" format="default"/>: </t>
+        <artwork name="" type="" align="left" alt=""><![CDATA[
 However, the problem is made more serious by introducing the full 
 range of Unicode code points into protocol strings.  For example, 
 the characters U+13DA U+13A2 U+13B5 U+13AC U+13A2 U+13AC U+13D2 from 
@@ -304,91 +255,69 @@ the Cherokee block look similar to the ASCII characters
 "STPETER" as they might appear when presented using a "creative" 
 font family.
 ]]></artwork>
-</figure>
-
-<t>NEW/ALLOWED:</t>
-
-<figure>
-<artwork><![CDATA[
+        <t>NEW/ALLOWED:</t>
+        <artwork name="" type="" align="left" alt=""><![CDATA[
 However, the problem is made more serious by introducing the full 
 range of Unicode code points into protocol strings.  For example, 
 the characters U+13DA U+13A2 U+13B5 U+13AC U+13A2 U+13AC U+13D2 
-((See PDF for non-ASCII character string)) from the Cherokee 
-block look similar to the ASCII characters "STPETER" as they might 
-appear when presented using a "creative" font family.
+(ᏚᎢᎵᎬᎢᎬᏒ) from the Cherokee block look similar to the ASCII
+characters "STPETER" as they might appear when presented using a
+"creative" font family.
 ]]></artwork>
-</figure>
-
-<t>ALSO ACCEPTABLE:</t>
-
-<figure>
-<artwork><![CDATA[
+        <t>ALSO ACCEPTABLE:</t>
+        <artwork name="" type="" align="left" alt=""><![CDATA[
 However, the problem is made more serious by introducing the full 
 range of Unicode code points into protocol strings.  For example, 
-the characters "(See PDF for non-ASCII character string)" (U+13DA 
-U+13A2 U+13B5 U+13AC U+13A2 U+13AC U+13D2) from the Cherokee block 
-look similar to the ASCII characters "STPETER" as they might 
-appear when presented using a "creative" font family.
+the characters "ᏚᎢᎵᎬᎢᎬᏒ" (U+13DA U+13A2 U+13B5 U+13AC U+13A2 U+13AC
+U+13D2) from the Cherokee block look similar to the ASCII characters
+"STPETER" as they might appear when presented using a "creative" font
+family.
 ]]></artwork>
-</figure>
-
-<t>Example of proper identification of Unicode
+        <t>Example of proper identification of Unicode
 characters in an RFC:</t>
-<t>Acceptable:</t>
-<t><list style="symbols">
-<t>Temperature changes in the Temperature Control Protocol are indicated
-by the U+2206 character.</t>
-</list>
-</t>
-
-<t> Preferred: </t>
-
-<t><list style="numbers">
-  <t>Temperature changes in the Temperature Control Protocol are
-indicated by the U+2206 character ("(See PDF for non-ASCII character string)").</t>
-
-  <t>Temperature changes in the Temperature Control Protocol are
-indicated by the U+2206 character (INCREMENT).</t>
-
-  <t>Temperature changes in the Temperature Control Protocol are
-indicated by the U+2206 character ("(See PDF for non-ASCII character string)", INCREMENT).</t>
-
-  <t>Temperature changes in the Temperature Control Protocol are
-indicated by the U+2206 character (INCREMENT, "(See PDF for non-ASCII character string)").</t>
-
-  <t>Temperature changes in the Temperature Control Protocol are
-indicated by the "Delta" character "(See PDF for non-ASCII character string)" (U+2206).</t>
-
-  <t>Temperature changes in the Temperature Control Protocol are
-indicated by the character "(See PDF for non-ASCII character string)" (INCREMENT, U+2206).</t>
-</list>
-</t>
-
-<t>
+        <t>Acceptable:</t>
+        <ul spacing="normal">
+          <li>Temperature changes in the Temperature Control Protocol are indicated
+by the U+2206 character.</li>
+        </ul>
+        <t> Preferred: </t>
+        <ol spacing="normal" type="1">
+          <li>Temperature changes in the Temperature Control Protocol are
+indicated by the U+2206 character ("<u>&#x2206;</u>").</li>
+          <li>Temperature changes in the Temperature Control Protocol are
+indicated by the U+2206 character (INCREMENT).</li>
+          <li>Temperature changes in the Temperature Control Protocol are
+indicated by the U+2206 character ("<u>&#x2206;</u>", INCREMENT).</li>
+          <li>Temperature changes in the Temperature Control Protocol are
+indicated by the U+2206 character (INCREMENT, "<u>&#x2206;</u>").</li>
+          <li>Temperature changes in the Temperature Control Protocol are
+indicated by the "Delta" character "<u>&#x2206;</u>" (U+2206).</li>
+          <li>Temperature changes in the Temperature Control Protocol are
+indicated by the character "<u>&#x2206;</u>" (INCREMENT, U+2206).</li>
+        </ol>
+        <t>
 Which option of (1), (2), (3), (4), (5), or (6) is preferred may depend
 on context and the specific character(s) in question.  All are acceptable 
-within an RFC.  "US-ASCII Escaping of Unicode Character" <xref target="BCP137"></xref> describes the pros and cons of different options for
+within an RFC.  "US-ASCII Escaping of Unicode Character" <xref target="BCP137" format="default"/> describes the pros and cons of different options for
  identifying Unicode characters and may help authors decide how to
  represent the non-ASCII characters in their documents.</t>
-</section>
-
-<section title="Tables">
-<t>
+      </section>
+      <section numbered="true" toc="default">
+        <name>Tables</name>
+        <t>
 Tables follow the same rules for identifiers and characters as in
-<xref target="botd">"Body of the Document"</xref>.  If it is sensible (i.e., more
+<xref target="botd" format="default">"Body of the Document"</xref>.  If it is sensible (i.e., more
   understandable for a reader) for a given document to have two tables, -- 
   one including the identifiers and non-ASCII characters and a 
   second with just the non-ASCII characters -- then that will be allowed
   at the discretion of the authors.
 </t>
-<t>
+        <t>
 Original text from "Preparation, Enforcement, and Comparison of
-Internationalized Strings Representing Usernames and Passwords" <xref
-target="RFC7613"/>. 
+Internationalized Strings Representing Usernames and Passwords" <xref target="RFC7613" format="default"/>. 
 </t>
-      <figure>
-        <preamble>Table 3: A sample of legal passwords</preamble>
-        <artwork><![CDATA[
+        <t>Table 3: A sample of legal passwords</t>
+        <artwork name="" type="" align="left" alt=""><![CDATA[
 +------------------------------------+------------------------------+
 | # | Password                       | Notes                        |
 +------------------------------------+------------------------------+
@@ -409,11 +338,9 @@ target="RFC7613"/>.
 |   |                                | <foo bar>                    |
 +------------------------------------+------------------------------+
         ]]></artwork>
-      </figure>
-<t>Preferred text:</t>
-      <figure>
-        <preamble>Table 3: A sample of legal passwords</preamble>
-        <artwork><![CDATA[
+        <t>Preferred text:</t>
+        <t>Table 3: A sample of legal passwords</t>
+        <artwork name="" type="" align="left" alt=""><![CDATA[
 +------------------------------------+------------------------------+
 | # | Password                       | Notes                        |
 +------------------------------------+------------------------------+
@@ -421,38 +348,37 @@ target="RFC7613"/>.
 +------------------------------------+------------------------------+
 | 13| <Correct Horse Battery Staple> | Different from example 12    |
 +------------------------------------+------------------------------+
-| 14| <(See PDF for non-ASCII        | Non-ASCII letters are OK     |
-|   |   character string)>           | (e.g., GREEK SMALL LETTER    |
+| 14| <πß๗>                          | Non-ASCII letters are OK     |
+|   |                                | (e.g., GREEK SMALL LETTER    |
 |   |                                | PI, U+03C0; LATIN SMALL      |
 |   |                                | LETTER SHARP S, U+00DF; THAI |
 |   |                                | DIGIT SEVEN, U+0E57)         |
 +------------------------------------+------------------------------+
-| 15| <Jack of (See PDF for non-     | Symbols are OK (e.g., BLACK  |
-|   |  ASCII character string)s>     | DIAMOND SUIT, U+2666)        |
+| 15| <Jack of ♦s>                   | Symbols are OK (e.g., BLACK  |
+|   |                                | DIAMOND SUIT, U+2666)        |
 +------------------------------------+------------------------------+
-| 16| <foo(See PDF for non-ASCII     | OGHAM SPACE MARK, U+1680, is | 
-|   |  character string)bar>         | mapped to U+0020 and thus    |
+| 16| <foo bar>                      | OGHAM SPACE MARK, U+1680, is | 
+|   |                                | mapped to U+0020 and thus    |
 |   |                                | the full string is mapped to |
 |   |                                | <foo bar>                    |
 +------------------------------------+------------------------------+
         ]]></artwork>
-      </figure>
-</section>
-
-<section title="Code Components">
-<t>
+      </section>
+      <section numbered="true" toc="default">
+        <name>Code Components</name>
+        <t>
 The RFC Editor encourages the use of the U+ notation except within a
 code component where one must follow the rules of the programming
 language in which the code is being written.
 </t>
-<t>
+        <t>
 Code components are generally expected to use fixed-width fonts. Where
 such fonts are not available for a particular script, the best script-appropriate font will be used for that part of the code component.
 </t>
-</section>
-
-<section title="Bibliographic Text">
-<t>
+      </section>
+      <section numbered="true" toc="default">
+        <name>Bibliographic Text</name>
+        <t>
 The reference entry must be in English; whatever subfields are present
 must be available in ASCII-encoded characters. For references to RFCs and Internet-Drafts, the author's name will be
 formatted in the reference as per current RFC Style Guide recommendations.
@@ -465,11 +391,8 @@ specialist or subject matter expert, review of any non-ASCII reference.
 
 This applies to both normative and informative references.
 </t>
-
-<t>Example:</t>
-
-<figure>
-<artwork><![CDATA[
+        <t>Example:</t>
+        <artwork name="" type="" align="left" alt=""><![CDATA[
 [GOST3410] "Information technology. Cryptographic data security. 
            Signature and verification processes of [electronic]
            digital signature.", GOST R 34.10-2001, Gosudarstvennyi 
@@ -477,30 +400,31 @@ This applies to both normative and informative references.
            Russia for Standards, 2001. (In Russian)
 
 Allowable addition to the above citation:
-           (See PDF for non-ASCII character strings)
+           "Информационная технология. Криптографическая защита
+            информации. Процессы формирования и проверки
+            электронной цифровой подписи", GOST R 34.10-2001,
+            Государственный стандарт Российской Федерации, 2001.
 
 Alternatively:
 [GOST3410] "Information technology. Cryptographic data security.
            Signature and verification processes of [electronic]
            digital signature.", GOST R 34.10-2001, Gosudarstvennyi
-           Standard of Russian Federation, (See PDF for non-ASCII 
-           character strings) (Government Committee of
+           Standard of Russian Federation, Правительственная
+           комиссия России по стандартам (Government Committee of
            Russia for Standards), 2001. (In Russian)
 ]]></artwork>
-</figure>
-
-</section>
-
-<section title="Keywords and Citation Tags">
-<t>
+      </section>
+      <section numbered="true" toc="default">
+        <name>Keywords and Citation Tags</name>
+        <t>
 Keywords (as tagged with the &lt;keyword&gt;  element in XML) and citation 
 tags (as defined in the anchor attributes of &lt;reference&gt; elements) must 
 contain only ASCII characters.
 </t>
-</section>
-
-<section title="Address Information">
-<t>
+      </section>
+      <section numbered="true" toc="default">
+        <name>Address Information</name>
+        <t>
 The purpose of providing address information, either postal or email,
 is to assist readers of an RFC in contacting the author or authors.  Authors 
 may include the official postal address as recognized by their company or 
@@ -509,10 +433,10 @@ the email address includes non-ASCII characters and is a valid email
 address at the time of publication, non-ASCII character escapes are not
 required.
 </t>
-<t>Example:</t>
-
-<figure>
-<artwork><![CDATA[
+        <t>Example:</t>
+<!-- Chinese and Hebrew need to be proofread, may not be transcribed
+	correctly -->
+        <artwork name="" type="" align="left" alt=""><![CDATA[
   Qin Wu (editor)
   Huawei
   101 Software Avenue, Yuhua District
@@ -520,7 +444,11 @@ required.
   China
 
 Additional contact information:
-  (See PDF for non-ASCII character strings)
+  吴钦 (editor)
+  华为技术有限公司
+  ⾬花区软件⼤道101号
+  江苏南京 210012
+   中国
 
 ------
 
@@ -531,192 +459,225 @@ Additional contact information:
   Israel
 
 Additional contact information:
-   (See PDF for non-ASCII character strings)
+   רוני אבן וואווי
+   דוד המלך 14
+   תל אביב 64953
+   ישראל
 ]]></artwork>
-</figure>
-
-</section>
-</section>
-
-<section title="Normalization Forms">
-<t>
-Authors should not expect normalization forms <xref target="UNICODE-NORM"/>to be preserved. If a
+      </section>
+    </section>
+    <section numbered="true" toc="default">
+      <name>Normalization Forms</name>
+      <t>
+Authors should not expect normalization forms <xref target="UNICODE-NORM" format="default"/>to be preserved. If a
 particular normalization form is expected, note that in the text of the
 RFC.
 </t>
-
-</section>
-
-<section title="XML Markup">
-<t>As described above, use of non-ASCII characters in areas such as
+    </section>
+    <section numbered="true" toc="default">
+      <name>XML Markup</name>
+      <t>As described above, use of non-ASCII characters in areas such as
 email, company name, address, and name is allowed. In order to make it 
 easier for code to identify the appropriate ASCII alternatives, authors
 must include an "ascii" attribute to their XML markup when an ASCII 
-alternative is required.  See <xref target="RFC7991"/> for 
+alternative is required.  See <xref target="RFC7991" format="default"/> for 
 more detail on how to tag ASCII alternatives.
 </t>
-</section>
-
-
-
-
-<section title="Internationalization Considerations">
-<t>
+    </section>
+    <section numbered="true" toc="default">
+      <name>Internationalization Considerations</name>
+      <t>
 The ability to use non-ASCII characters in RFCs in a clear and consistent 
 manner will improve the ability to describe internationalized protocols 
 and will recognize the diversity of authors. However, the goal of readability
 will override the use of non-ASCII characters within the text.
 </t>
-</section>
-
-<section title="Security Considerations">
-<t>
+    </section>
+    <section numbered="true" toc="default">
+      <name>Security Considerations</name>
+      <t>
 Valid Unicode that matches the expected text must be verified in order
 to preserve expected behavior and protocol information.
 </t>
-</section>
+    </section>
+  </middle>
+  <back>
+    <references>
+      <name>Informative References</name>
+      <reference anchor="RFC20" target="http://www.rfc-editor.org/info/rfc20">
+        <front>
+          <title>ASCII format for network interchange</title>
+          <seriesInfo name="DOI" value="10.17487/RFC0020"/>
+          <seriesInfo name="RFC" value="20"/>
+          <seriesInfo name="STD" value="80"/>
+          <author initials="V.G." surname="Cerf" fullname="V.G. Cerf">
+            <organization/>
+          </author>
+          <date year="1969" month="October"/>
+        </front>
+      </reference>
+      <reference anchor="RFC4475" target="https://www.rfc-editor.org/info/rfc4475" xml:base="https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4475.xml">
+        <front>
+          <title>Session Initiation Protocol (SIP) Torture Test Messages</title>
+          <seriesInfo name="DOI" value="10.17487/RFC4475"/>
+          <seriesInfo name="RFC" value="4475"/>
+          <author initials="R." surname="Sparks" fullname="R. Sparks" role="editor">
+            <organization/>
+          </author>
+          <author initials="A." surname="Hawrylyshen" fullname="A. Hawrylyshen">
+            <organization/>
+          </author>
+          <author initials="A." surname="Johnston" fullname="A. Johnston">
+            <organization/>
+          </author>
+          <author initials="J." surname="Rosenberg" fullname="J. Rosenberg">
+            <organization/>
+          </author>
+          <author initials="H." surname="Schulzrinne" fullname="H. Schulzrinne">
+            <organization/>
+          </author>
+          <date year="2006" month="May"/>
+          <abstract>
+            <t>This informational document gives examples of Session Initiation Protocol (SIP) test messages designed to exercise and "torture" a SIP implementation.  This memo provides information for the Internet community.</t>
+          </abstract>
+        </front>
+      </reference>
+      <reference anchor="RFC7322" target="https://www.rfc-editor.org/info/rfc7322" xml:base="https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7322.xml">
+        <front>
+          <title>RFC Style Guide</title>
+          <seriesInfo name="DOI" value="10.17487/RFC7322"/>
+          <seriesInfo name="RFC" value="7322"/>
+          <author initials="H." surname="Flanagan" fullname="H. Flanagan">
+            <organization/>
+          </author>
+          <author initials="S." surname="Ginoza" fullname="S. Ginoza">
+            <organization/>
+          </author>
+          <date year="2014" month="September"/>
+          <abstract>
+            <t>This document describes the fundamental and unique style conventions and editorial policies currently in use for the RFC Series.  It captures the RFC Editor's basic requirements and offers guidance regarding the style and structure of an RFC.  Additional guidance is captured on a website that reflects the experimental nature of that guidance and prepares it for future inclusion in the RFC Style Guide.  This document obsoletes RFC 2223, "Instructions to RFC Authors".</t>
+          </abstract>
+        </front>
+      </reference>
+      <reference anchor="RFC7564" target="https://www.rfc-editor.org/info/rfc7564" xml:base="https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7564.xml">
+        <front>
+          <title>PRECIS Framework: Preparation, Enforcement, and Comparison of Internationalized Strings in Application Protocols</title>
+          <seriesInfo name="DOI" value="10.17487/RFC7564"/>
+          <seriesInfo name="RFC" value="7564"/>
+          <author initials="P." surname="Saint-Andre" fullname="P. Saint-Andre">
+            <organization/>
+          </author>
+          <author initials="M." surname="Blanchet" fullname="M. Blanchet">
+            <organization/>
+          </author>
+          <date year="2015" month="May"/>
+          <abstract>
+            <t>Application protocols using Unicode characters in protocol strings need to properly handle such strings in order to enforce internationalization rules for strings placed in various protocol slots (such as addresses and identifiers) and to perform valid comparison operations (e.g., for purposes of authentication or authorization).  This document defines a framework enabling application protocols to perform the preparation, enforcement, and comparison of internationalized strings ("PRECIS") in a way that depends on the properties of Unicode characters and thus is agile with respect to versions of Unicode.  As a result, this framework provides a more sustainable approach to the handling of internationalized strings than the previous framework, known as Stringprep (RFC 3454).  This document obsoletes RFC 3454.</t>
+          </abstract>
+        </front>
+      </reference>
+      <reference anchor="RFC7613" target="https://www.rfc-editor.org/info/rfc7613" xml:base="https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7613.xml">
+        <front>
+          <title>Preparation, Enforcement, and Comparison of Internationalized Strings Representing Usernames and Passwords</title>
+          <seriesInfo name="DOI" value="10.17487/RFC7613"/>
+          <seriesInfo name="RFC" value="7613"/>
+          <author initials="P." surname="Saint-Andre" fullname="P. Saint-Andre">
+            <organization/>
+          </author>
+          <author initials="A." surname="Melnikov" fullname="A. Melnikov">
+            <organization/>
+          </author>
+          <date year="2015" month="August"/>
+          <abstract>
+            <t>This document describes updated methods for handling Unicode strings representing usernames and passwords.  The previous approach was known as SASLprep (RFC 4013) and was based on stringprep (RFC 3454). The methods specified in this document provide a more sustainable approach to the handling of internationalized usernames and passwords.  The preparation, enforcement, and comparison of internationalized strings (PRECIS) framework, RFC 7564, obsoletes RFC 3454, and this document obsoletes RFC 4013.</t>
+          </abstract>
+        </front>
+      </reference>
+      <!--&I-D.iab-xml2rfc; companion document RFC 7991-->
 
+<reference anchor="RFC7991" target="http://www.rfc-editor.org/info/rfc7991">
+        <front>
+          <title>The "xml2rfc" Version 3 Vocabulary</title>
+          <seriesInfo name="DOI" value="10.17487/RFC7991"/>
+          <seriesInfo name="RFC" value="7991"/>
+          <author initials="P" surname="Hoffman" fullname="Paul Hoffman">
+            <organization/>
+          </author>
+          <date month="December" year="2016"/>
+          <abstract>
+            <t>This document defines the "xml2rfc" version 3 vocabulary: an XML- based language used for writing RFCs and Internet-Drafts.  It is heavily derived from the version 2 vocabulary that is also under discussion.  This document obsoletes the v2 grammar described in RFC 2629 and its followup, RFC 7749.  Editorial Note (To be removed by RFC Editor)  Discussion of this draft takes place on the rfc-interest mailing list (rfc-interest@rfc-editor.org), which has its home page at &lt;https://www.rfc-editor.org/mailman/listinfo/rfc-interest&gt;.</t>
+          </abstract>
+        </front>
+      </reference>
+      <reference anchor="BCP137" target="http://www.rfc-editor.org/info/bcp137">
+        <front>
+          <title>ASCII Escaping of Unicode Characters</title>
+          <seriesInfo name="RFC" value="5137"/>
+          <seriesInfo name="BCP" value="137"/>
+          <author initials="J." surname="Klensin" fullname="J. Klensin">
+            <organization/>
+          </author>
+          <date year="2008" month="February"/>
+        </front>
+      </reference>
+      <reference anchor="MerrWeb">
+        <front>
+          <title>Merriam-Webster's Collegiate Dictionary, 11th Edition</title>
+          <author>
+            <organization>Merriam-Webster, Inc.</organization>
+          </author>
+          <date year="2009"/>
+        </front>
+      </reference>
+      <reference anchor="UnicodeCurrent" target="http://www.unicode.org/versions/latest/">
+        <front>
+          <title>The Unicode Standard</title>
+          <author>
+            <organization>The Unicode Consortium</organization>
+          </author>
+          <date/>
+        </front>
+      </reference>
+      <reference anchor="UNICODE-CHART" target="http://www.unicode.org/charts">
+        <front>
+          <title>The Unicode Standard</title>
+          <author>
+            <organization>The Unicode Consortium</organization>
+          </author>
+          <date/>
+        </front>
+      </reference>
+      <reference anchor="UNICODE-NORM" target="http://www.unicode.org/reports/tr15/">
+        <front>
+          <title>Unicode Standard Annex #15: Unicode Normalization Forms</title>
+          <author>
+            <organization>The Unicode Consortium</organization>
+          </author>
+          <date year="2016"/>
+        </front>
+      </reference>
+    </references>
+    <section numbered="false" toc="default">
+      <name>IAB Members at the Time of Approval</name>
+      <t>The IAB members at the time this memo was approved were (in alphabetical order):                                                       
 
-
-</middle>
-
-<back>
-
-<references title="Informative References">
-
-
-<reference  anchor='RFC20' target='http://www.rfc-editor.org/info/rfc20'>
-<front>
-<title>ASCII format for network interchange</title>
-<author initials='V.G.' surname='Cerf' fullname='V.G. Cerf'><organization /></author>
-<date year='1969' month='October' />
-</front>
-<seriesInfo name='STD' value='80'/>
-<seriesInfo name='RFC' value='20'/>
-<seriesInfo name='DOI' value='10.17487/RFC0020'/>
-</reference>
-
-
-&RFC4475;
-&RFC7322;
-&RFC7564;
-&RFC7613;
-
-
-<!--&I-D.iab-xml2rfc; companion document RFC 7991-->
-
-<reference anchor='RFC7991' target='http://www.rfc-editor.org/info/rfc7991'>
-<front>
-<title>The "xml2rfc" Version 3 Vocabulary</title>
-
-<author initials='P' surname='Hoffman' fullname='Paul Hoffman'>
-    <organization />
-</author>
-
-<date month='December' year='2016' />
-
-<abstract><t>This document defines the "xml2rfc" version 3 vocabulary: an XML- based language used for writing RFCs and Internet-Drafts.  It is heavily derived from the version 2 vocabulary that is also under discussion.  This document obsoletes the v2 grammar described in RFC 2629 and its followup, RFC 7749.  Editorial Note (To be removed by RFC Editor)  Discussion of this draft takes place on the rfc-interest mailing list (rfc-interest@rfc-editor.org), which has its home page at &lt;https://www.rfc-editor.org/mailman/listinfo/rfc-interest>.</t></abstract>
-
-</front>
-
-<seriesInfo name='RFC' value='7991' />
-<seriesInfo name="DOI" value="10.17487/RFC7991"/>
-</reference>
-
-
-<reference anchor="BCP137" target="http://www.rfc-editor.org/info/bcp137">
- <front>
-  <title>ASCII Escaping of Unicode Characters</title>
-  <author initials="J." surname="Klensin" fullname="J. Klensin">
-    <organization />
-  </author>
-  <date year="2008" month="February" />
- </front>
-  <seriesInfo name='BCP' value='137'/>
-  <seriesInfo name='RFC' value='5137'/>
-</reference>
-
-
-<reference anchor="MerrWeb">
-  <front>
-    <title>Merriam-Webster's Collegiate Dictionary, 11th Edition</title>
-    <author>
-      <organization>Merriam-Webster, Inc.</organization>
-    </author>
-    <date year="2009" />
-  </front>
-</reference>
-
-
-<reference anchor="UnicodeCurrent" target="http://www.unicode.org/versions/latest/">
-  <front>
-    <title>The Unicode Standard</title>
-    <author>
-      <organization>The Unicode Consortium</organization>
-    </author>
-    <date/>
-  </front>
-</reference>
-
-<reference anchor="UNICODE-CHART" target="http://www.unicode.org/charts">
-  <front>
-    <title>The Unicode Standard</title>
-    <author>
-      <organization>The Unicode Consortium</organization>
-    </author>
-    <date />
-  </front>
-</reference>
-
-
-<reference anchor="UNICODE-NORM" target="http://www.unicode.org/reports/tr15/">
-  <front>
-    <title>Unicode Standard Annex #15: Unicode Normalization Forms</title>
-    <author>
-      <organization>The Unicode Consortium</organization>
-    </author>
-    <date year="2016"/>
-  </front>
-</reference>
-
-
-
-</references>
-
-  <section title="IAB Members at the Time of Approval" numbered="no">
-
-  <t>The IAB members at the time this memo was approved were (in alphabetical order):                                                       
-
-<?rfc subcompact="yes" ?>
-<list>
- <t>Jari Arkko</t>
- <t>Ralph Droms</t>
- <t>Ted Hardie</t>
- <t>Joe Hildebrand</t>
- <t>Russ Housley</t>
-<t>Lee Howard</t>
- <t>Erik Nordmark</t>
- <t>Robert Sparks</t>
- <t>Andrew Sullivan</t>
- <t>Dave Thaler</t>
-<t>Martin Thomson</t>
- <t>Brian Trammell</t>
- <t>Suzanne Woolf</t>
-</list>
-<?rfc subcompact="no" ?>
-  </t>
-  </section>
-
-<section title="Acknowledgements" numbered="no">
-<t>
+ 
+ 
+      </t>
+      <ul empty="true" spacing="compact">
+        <li>... current list goes here ...</li>
+      </ul>
+    </section>
+    <section numbered="false" toc="default">
+      <name>Acknowledgements</name>
+      <t>
 With many thanks to the members of the IAB i18n program.  Also, many thanks to
 the RFC Format Design Team for their efforts in making this transition
 successful: Nevil Brownlee (ISE), Tony Hansen, Joe Hildebrand, Paul Hoffman,
 Ted Lemon, Julian Reschke, Adam Roach, Alice Russo, Robert Sparks (Tools Team
 liaison), and Dave Thaler.
+The previous version of this document was edited by Heather Flanagan.
 </t>
-
-</section>
-</back>
-
+    </section>
+  </back>
 </rfc>


### PR DESCRIPTION
I ran the XML through xml2rfc --v2v3, then cut and paste the non-ASCII text from the 7997 PDF, and made a few other tweaks including putting in the correct  (U+2206) delta characters.